### PR TITLE
ITOOLS-719: Update ref for micro image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - '8600:8600/tcp'
       - '8600:8600/udp'
   proxy_sidecar:
-    image: microhq/micro:latest
+    image: micro/micro:latest
     command: --api_handler=proxy
              --api_namespace=go.micro.srv
              --api_address=0.0.0.0:8181


### PR DESCRIPTION
### Why is this pull request necessary?
* `microhq/micro` no longer exists

### How does it fix the issue?
* Appears to have moved to https://hub.docker.com/r/micro/micro
* Update references.

### What side effects might this have?
